### PR TITLE
refactor(B3): drop contactus from CoreExtensions() composition root

### DIFF
--- a/core_modules.go
+++ b/core_modules.go
@@ -2,7 +2,6 @@ package sneat_core_modules
 
 import (
 	"github.com/sneat-co/sneat-core-modules/auth"
-	"github.com/sneat-co/sneat-core-modules/contactus"
 	"github.com/sneat-co/sneat-core-modules/generic"
 	"github.com/sneat-co/sneat-core-modules/invitus"
 	"github.com/sneat-co/sneat-core-modules/linkage"
@@ -11,10 +10,15 @@ import (
 	"github.com/sneat-co/sneat-go-core/extension"
 )
 
+// CoreExtensions returns the core module extensions.
+//
+// NOTE: contactus is intentionally NOT included here. It has been extracted into its own
+// module (github.com/sneat-co/contactus/backend); consumers must register
+// contactusext.Extension() themselves at the application composition root. Including it here
+// would force core-modules to import the contactus module and re-create a module cycle.
 func CoreExtensions() []extension.Config {
 	return []extension.Config{
 		auth.Extension(),
-		contactus.Extension(),
 		generic.Extension(),
 		invitus.Extension(),
 		linkage.Extension(),


### PR DESCRIPTION
## What
Removes `contactus.Extension()` (and its import) from `CoreExtensions()`.

## Why
contactus has been extracted into its own module (`github.com/sneat-co/contactus/backend`, see sneat-co/contactus#2). Keeping `contactus.Extension()` in core-modules' composition root would force core-modules to import the contactus module — and since `contactus/backend` imports core-modules (spaceus/linkage/userus/invitus + the registration facades), that re-creates the module cycle the B1 cycle-break removed.

Consumers now register `contactusext.Extension()` themselves at their app composition root (e.g. sneat-go-backend `standardExtensions()`).

## ⚠️ Release coordination
This is a coordinated-release change. Once tagged (planned `v0.38.60`), any consumer bumping to it **loses contactus auto-wiring** until it adds `contactusext.Extension()`. Tag only when consumers are ready (their repoint branches are prepared). core-modules still ships the `contactus/` packages for now (dropped later in B4), so old import paths keep resolving.

## Verification
`go build ./...` green. contactus is not referenced anywhere else in core-modules (B1 removed the sibling-module edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)