### PR TITLE
feat(spaceus): SpaceTypeSystem open writes + provisioning guard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gosimple/slug v1.15.0
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7
 	github.com/sneat-co/contactus-ext/backend v0.1.0
-	github.com/sneat-co/sneat-go-core v0.55.6
+	github.com/sneat-co/sneat-go-core v0.57.0
 	github.com/stretchr/testify v1.11.1
 	github.com/strongo/delaying v0.2.2
 	github.com/strongo/facebook v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/sneat-co/contactus-ext/backend v0.1.0 h1:b5C8+gxOoyxAzEilMZaQ/LXTtgdy
 github.com/sneat-co/contactus-ext/backend v0.1.0/go.mod h1:B6Ivk2AM/KCpLPIZpdMwjam9vYRYRXDie0mFCeessEM=
 github.com/sneat-co/sneat-go-core v0.55.6 h1:8Tg+vCJMl9YCYUj9ltTZ++yg0XnlNF7z0HfdQBt8K+Q=
 github.com/sneat-co/sneat-go-core v0.55.6/go.mod h1:da7Yy6qj4QMs+PkeK+tr0Y7Eyw2A6hd7cKpLg8+N4Tk=
+github.com/sneat-co/sneat-go-core v0.57.0 h1:fZyXx1GIPMHBZboIbfawGOtfuAuQVqtBgeerN6eV7oE=
+github.com/sneat-co/sneat-go-core v0.57.0/go.mod h1:da7Yy6qj4QMs+PkeK+tr0Y7Eyw2A6hd7cKpLg8+N4Tk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/spaceus/dal4spaceus/module_space_worker.go
+++ b/spaceus/dal4spaceus/module_space_worker.go
@@ -138,7 +138,14 @@ func RunModuleSpaceWorkerWithUserCtx[D SpaceModuleDbo](
 	if err = db.Get(ctx, spaceWorkerParams.Space.Record); err != nil {
 		return fmt.Errorf("failed to get space record outside of transaction: %w", err)
 	}
-	if userID := spaceWorkerParams.UserID(); userID != "" {
+	if spaceWorkerParams.Space.Data.Type == coretypes.SpaceTypeSystem {
+		// System spaces accept writes from any authenticated user (membership is
+		// not required); per-record authorization is delegated to the owning
+		// extension. Unauthenticated writes are rejected.
+		if spaceWorkerParams.UserID() == "" {
+			return fmt.Errorf("%w: authentication is required to write to a system space", facade.ErrUnauthorized)
+		}
+	} else if userID := spaceWorkerParams.UserID(); userID != "" {
 		if !slices.Contains(spaceWorkerParams.Space.Data.UserIDs, userID) {
 			return fmt.Errorf("%w: user is not a member of the space", facade.ErrUnauthorized)
 		}

--- a/spaceus/dal4spaceus/space_worker.go
+++ b/spaceus/dal4spaceus/space_worker.go
@@ -78,7 +78,10 @@ func (v SpaceWorkerParams) GetRecords(ctx context.Context, tx dal.MultiGetter, r
 		if !v.Space.Record.Exists() {
 			return errors.New("space record does not exist")
 		}
-		if !slices.Contains(v.Space.Data.UserIDs, userID) {
+		// System spaces are not gated by membership: any authenticated user may
+		// access records (per-record authorization is delegated to the owning
+		// extension), and reads are public.
+		if v.Space.Data.Type != coretypes.SpaceTypeSystem && !slices.Contains(v.Space.Data.UserIDs, userID) {
 			return fmt.Errorf("%w: space record has no current userID in UserIDs field: %s", facade.ErrUnauthorized, userID)
 		}
 	}

--- a/spaceus/dal4spaceus/system_space_test.go
+++ b/spaceus/dal4spaceus/system_space_test.go
@@ -1,0 +1,105 @@
+package dal4spaceus
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/mocks/mock_dal"
+	"github.com/sneat-co/sneat-core-modules/spaceus/dbo4spaceus"
+	"github.com/sneat-co/sneat-go-core/coretypes"
+	"github.com/sneat-co/sneat-go-core/facade"
+	"github.com/sneat-co/sneat-go-core/models/dbmodels"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// fillSpace sets a loaded space record to the given type with the given members.
+func fillSpace(data *dbo4spaceus.SpaceDbo, spaceType coretypes.SpaceType, userIDs []string) {
+	data.Type = spaceType
+	data.Title = "Test Space"
+	data.Status = dbmodels.StatusActive
+	data.UserIDs = userIDs
+	data.CreatedBy = "creator"
+	data.CreatedAt = time.Now()
+	data.UpdatedBy = data.CreatedBy
+	data.UpdatedAt = data.CreatedAt
+	data.Version = 1
+}
+
+// Task 3 (non-member write) + Task 4 (authenticated read): an authenticated user
+// who is NOT a member may access records in a System space, whereas a non-member
+// in a non-System space is rejected.
+func TestSpaceWorkerParams_GetRecords_SystemSpaceSkipsMembership(t *testing.T) {
+	const spaceID = "games"
+	const nonMemberUserID = "outsider"
+
+	tests := []struct {
+		name      string
+		spaceType coretypes.SpaceType
+		wantErr   bool
+	}{
+		{name: "system_non_member_allowed", spaceType: coretypes.SpaceTypeSystem, wantErr: false},
+		{name: "private_non_member_rejected", spaceType: coretypes.SpaceTypePrivate, wantErr: true},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := SpaceWorkerParams{
+				Space:   dbo4spaceus.NewSpaceEntry(spaceID),
+				UserCtx: facade.NewUserContext(nonMemberUserID),
+			}
+			ctrl := gomock.NewController(t)
+			tx := mock_dal.NewMockReadTransaction(ctrl)
+			tx.EXPECT().GetMulti(ctx, gomock.Any()).Times(1).Do(
+				func(ctx context.Context, records []dal.Record) error {
+					for i := range records {
+						records[i].SetError(nil)
+					}
+					// the space record carries members that exclude nonMemberUserID
+					fillSpace(params.Space.Data, tt.spaceType, []string{"member1"})
+					return nil
+				})
+			err := params.GetRecords(ctx, tx, params.Space.Record)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, facade.ErrUnauthorized))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Task 3 (unauthenticated write rejected): a write to a System space with no
+// authenticated user is rejected by the pre-transaction check before any
+// transaction runs.
+func TestRunModuleSpaceWorkerWithUserCtx_SystemSpaceRejectsUnauthenticated(t *testing.T) {
+	const spaceID coretypes.SpaceID = "games"
+	const moduleID = "test_module"
+	ctxNoUser := facade.NewContextWithUser(context.Background(), nil)
+
+	facade.GetSneatDB = func(ctx context.Context) (dal.DB, error) {
+		ctrl := gomock.NewController(t)
+		db := mock_dal.NewMockDB(ctrl)
+		// The space is loaded outside the transaction; mark it as a System space.
+		db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, record dal.Record) error {
+				record.SetError(nil)
+				fillSpace(record.Data().(*dbo4spaceus.SpaceDbo), coretypes.SpaceTypeSystem, []string{"member1"})
+				return nil
+			})
+		// RunReadwriteTransaction must NOT be called: the unauthenticated write is
+		// rejected before any transaction starts (no EXPECT() registered for it).
+		return db, nil
+	}
+
+	worker := func(ctx facade.ContextWithUser, tx dal.ReadwriteTransaction, params *ModuleSpaceWorkerParams[*fooModuleSpaceData]) error {
+		return nil
+	}
+	err := RunModuleSpaceWorkerWithUserCtx(ctxNoUser, spaceID, moduleID, new(fooModuleSpaceData), worker)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, facade.ErrUnauthorized))
+}

--- a/spaceus/dto4spaceus/create_space.go
+++ b/spaceus/dto4spaceus/create_space.go
@@ -21,6 +21,9 @@ func (request *CreateSpaceRequest) Validate() error {
 	if strings.TrimSpace(string(request.Type)) == "" {
 		return validation.NewErrRecordIsMissingRequiredField("type")
 	}
+	if request.Type == coretypes.SpaceTypeSystem {
+		return validation.NewErrBadRequestFieldValue("type", "system spaces are provisioned by the platform only")
+	}
 	if request.Type != coretypes.SpaceTypeFamily &&
 		request.Type != coretypes.SpaceTypePrivate &&
 		strings.TrimSpace(request.Title) == "" {

--- a/spaceus/dto4spaceus/create_space_test.go
+++ b/spaceus/dto4spaceus/create_space_test.go
@@ -1,0 +1,28 @@
+package dto4spaceus
+
+import (
+	"testing"
+
+	"github.com/sneat-co/sneat-go-core/coretypes"
+)
+
+func TestCreateSpaceRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		request CreateSpaceRequest
+		wantErr bool
+	}{
+		{name: "family_ok", request: CreateSpaceRequest{Type: coretypes.SpaceTypeFamily}, wantErr: false},
+		{name: "company_with_title_ok", request: CreateSpaceRequest{Type: coretypes.SpaceTypeCompany, Title: "Acme"}, wantErr: false},
+		{name: "empty_type_rejected", request: CreateSpaceRequest{Type: ""}, wantErr: true},
+		{name: "system_rejected", request: CreateSpaceRequest{Type: coretypes.SpaceTypeSystem, Title: "Games"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Implements the spaceus side of the **system-space-type** plan (spec: `sneat-co/sneat-specs` → `spec/plans/system-space-type.md`), consuming `sneat-go-core` `v0.57.0` (`SpaceTypeSystem`).

A System space is platform-owned and not tied to per-user membership: any authenticated user may write its module records, reads are public, and per-record authorization is delegated to the owning extension.

## Spike finding (why two gates)

The plan's "single chokepoint" assumption was **false**. Membership is enforced in **two** places, so both are branched on `space.Type == System`:

1. `dal4spaceus/module_space_worker.go` — `RunModuleSpaceWorkerWithUserCtx` pre-transaction check.
2. `dal4spaceus/space_worker.go` — `SpaceWorkerParams.GetRecords` load-time check.

## Changes

- **Write access (Task 3):** for System spaces, allow authenticated non-member writes, **reject unauthenticated** writes (pre-check), and skip membership in both gates.
- **Public read (Task 4):** the `GetRecords` branch lets authenticated non-members read; unauthenticated reads already bypass the membership block → System reads are public.
- **Provisioning guard (Task 5):** `dto4spaceus.CreateSpaceRequest.Validate()` rejects `Type=System` from the end-user create-space path.
- Bumps `sneat-go-core` `v0.55.6 → v0.57.0`.

## Tests

- `TestSpaceWorkerParams_GetRecords_SystemSpaceSkipsMembership` — System non-member allowed; Private non-member rejected.
- `TestRunModuleSpaceWorkerWithUserCtx_SystemSpaceRejectsUnauthenticated` — unauthenticated System write rejected before any tx.
- `TestCreateSpaceRequest_Validate` — System type rejected.

`go build ./...` and `go test ./spaceus/...` pass.

## Audit note / follow-up

`RunModuleSpaceWorkerTx` / `RunSpaceWorkerTx` (internal tx-composition helpers) do not pre-check auth; they rely on `GetRecords` (branched here). The unauthenticated-write rejection lives only on the main `RunModuleSpaceWorkerWithUserCtx` path — consistent with the "extension authorizes before writing" contract. Consolidating the two gates is a tracked follow-up.

Verifies: system-space-type#ac:non-member-authenticated-write-succeeds, system-space-type#ac:unauthenticated-write-rejected, system-space-type#ac:spaceus-does-not-gate-record-by-membership, system-space-type#ac:public-read-succeeds, system-space-type#ac:user-cannot-create-system-space

🤖 Generated with [Claude Code](https://claude.com/claude-code)