### PR TITLE
feat(linkage): spaceless system namespace for global extension records (Decision 0002)

### DIFF
--- a/linkage/dbo4linkage/item_ref.go
+++ b/linkage/dbo4linkage/item_ref.go
@@ -81,6 +81,15 @@ func (v ItemRef) ExtensionCollectionID() string {
 	return fmt.Sprintf("m=%s&c=%s", v.ExtID, v.Collection)
 }
 
+// DocID returns the bare document id with any optional "@{spaceID}" suffix
+// removed. For a bare itemID it returns the itemID unchanged.
+func (v ItemRef) DocID() string {
+	if i := strings.Index(v.ItemID, SpaceItemIDSeparator); i >= 0 {
+		return v.ItemID[:i]
+	}
+	return v.ItemID
+}
+
 func (v ItemRef) Validate() error {
 	// SpaceID can be empty for global collections like Happening
 	if v.ExtID == "" {
@@ -91,7 +100,27 @@ func (v ItemRef) Validate() error {
 	}
 	if v.ItemID == "" {
 		return validation.NewErrRecordIsMissingRequiredField("itemID")
-	} else if err := validate.RecordID(v.ItemID); err != nil {
+	}
+	// The ItemID may carry at most one optional "@{spaceID}" suffix (sneat-specs
+	// Decision 0002). "@" is the reserved space separator, so a document id must
+	// never contain it: split on the first "@" and require both the document id
+	// and the spaceID segment to be non-empty, and the spaceID to hold no further
+	// "@". A bare itemID (no "@") is the common case.
+	docID := v.ItemID
+	if i := strings.Index(v.ItemID, SpaceItemIDSeparator); i >= 0 {
+		docID = v.ItemID[:i]
+		spaceID := v.ItemID[i+1:]
+		if docID == "" {
+			return validation.NewErrBadRecordFieldValue("itemID", "empty document id before '@' separator")
+		}
+		if spaceID == "" {
+			return validation.NewErrBadRecordFieldValue("itemID", "empty spaceID after '@' separator")
+		}
+		if strings.Contains(spaceID, SpaceItemIDSeparator) {
+			return validation.NewErrBadRecordFieldValue("itemID", "must not contain more than one '@' separator")
+		}
+	}
+	if err := validate.RecordID(docID); err != nil {
 		return validation.NewErrBadRecordFieldValue("itemID", err.Error())
 	}
 	return nil

--- a/linkage/dbo4linkage/item_ref_full.go
+++ b/linkage/dbo4linkage/item_ref_full.go
@@ -6,12 +6,18 @@ import (
 
 const SpaceItemIDSeparator = "@"
 
+// specscore: decisions/0002-reserved-extension-space-ids
+// Ref serialization: omit the "@{spaceID}" suffix for the spaceless system
+// namespace. See sneat-specs Decision 0002:
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
 func NewFullItemRef(extID coretypes.ExtID, collection string, spaceID coretypes.SpaceID, itemID string) ItemRef {
-	if spaceID == "" {
-		panic("spaceID is required for a full item reference")
-	}
 	if itemID == "" {
 		panic("itemID is required for a full item reference")
+	}
+	if spaceID == "" {
+		// Spaceless system namespace: no "@{spaceID}" suffix is appended.
+		// The record resolves under /ext/{ext-id}/{collection}/{item-id}.
+		return newItemRef(extID, collection, itemID)
 	}
 	return newItemRef(extID, collection, itemID+SpaceItemIDSeparator+string(spaceID))
 }

--- a/linkage/dbo4linkage/item_ref_full_test.go
+++ b/linkage/dbo4linkage/item_ref_full_test.go
@@ -29,7 +29,9 @@ func TestNewContactFullRef(t *testing.T) {
 			},
 		},
 		{
-			name: "panic on empty space",
+			// sneat-specs Decision 0002: an empty spaceID denotes the spaceless
+			// system namespace, so no "@{spaceID}" suffix is appended (no panic).
+			name: "empty space resolves to system namespace",
 			args: args{
 				spaceID:   "",
 				contactID: "test-contact-id",
@@ -56,13 +58,6 @@ func TestNewContactFullRef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.args.contactID == "" {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf("NewFullItemRef() did not panic on empty itemID")
-					}
-				}()
-			}
-			if tt.args.spaceID == "" {
 				defer func() {
 					if r := recover(); r == nil {
 						t.Errorf("NewFullItemRef() did not panic on empty itemID")

--- a/linkage/dbo4linkage/item_ref_test.go
+++ b/linkage/dbo4linkage/item_ref_test.go
@@ -1,0 +1,52 @@
+package dbo4linkage
+
+import "testing"
+
+// TestItemRef_Validate covers the "@" reserved-separator rules from sneat-specs
+// Decision 0002: a bare itemID and a well-formed "itemID@{spaceID}" composite
+// are valid; a trailing "@" (empty space), a leading "@" (empty doc id), and
+// more than one "@" (an embedded separator in the document id) are rejected.
+func TestItemRef_Validate(t *testing.T) {
+	newRef := func(itemID string) ItemRef {
+		return ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: itemID}
+	}
+	tests := []struct {
+		name    string
+		ref     ItemRef
+		wantErr bool
+	}{
+		{name: "bare", ref: newRef("item1"), wantErr: false},
+		{name: "space_bound_composite", ref: newRef("item1@space1"), wantErr: false},
+		{name: "trailing_at_empty_space", ref: newRef("item1@"), wantErr: true},
+		{name: "leading_at_empty_doc", ref: newRef("@space1"), wantErr: true},
+		{name: "double_at", ref: newRef("item1@space1@x"), wantErr: true},
+		{name: "missing_item_id", ref: newRef(""), wantErr: true},
+		{name: "missing_ext_id", ref: ItemRef{Collection: "contacts", ItemID: "item1"}, wantErr: true},
+		{name: "missing_collection", ref: ItemRef{ExtID: "contactus", ItemID: "item1"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.ref.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("ItemRef.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestItemRef_DocID verifies stripping of the optional "@{spaceID}" suffix.
+func TestItemRef_DocID(t *testing.T) {
+	tests := []struct {
+		itemID string
+		want   string
+	}{
+		{itemID: "item1", want: "item1"},
+		{itemID: "item1@space1", want: "item1"},
+		{itemID: "item1@", want: "item1"},
+	}
+	for _, tt := range tests {
+		ref := ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: tt.itemID}
+		if got := ref.DocID(); got != tt.want {
+			t.Errorf("ItemRef.DocID() for %q = %q, want %q", tt.itemID, got, tt.want)
+		}
+	}
+}

--- a/linkage/dbo4linkage/related_to.go
+++ b/linkage/dbo4linkage/related_to.go
@@ -20,9 +20,12 @@ type RelationshipItemRolesCommand struct {
 }
 
 func (v RelationshipItemRolesCommand) Validate() error {
-	//if err := v.ItemRef.Validate(); err != nil {
-	//	return err
-	//}
+	// Validate the (untrusted) related ItemRef: rejects a malformed "@" suffix
+	// such as a trailing "@" (empty spaceID) or an embedded "@" in the document
+	// id (sneat-specs Decision 0002 — "@" is the reserved space separator).
+	if err := v.ItemRef.Validate(); err != nil {
+		return validation.NewErrBadRequestFieldValue("itemRef", err.Error())
+	}
 	if err := v.Add.Validate(); err != nil {
 		return validation.NewErrBadRequestFieldValue("add", err.Error())
 	}

--- a/linkage/dbo4linkage/with_related.go
+++ b/linkage/dbo4linkage/with_related.go
@@ -31,14 +31,25 @@ type RelatedItemKey struct {
 	ItemID  string            `json:"itemID" firestore:"itemID"`
 }
 
+// specscore: decisions/0002-reserved-extension-space-ids
+// Ref serialization for the spaceless system namespace: omit the "@{spaceID}"
+// suffix when there is no space. See sneat-specs Decision 0002:
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
 func (v RelatedItemKey) String() string {
+	if v.SpaceID == "" {
+		// System namespace (spaceless) reference: no "@{spaceID}" suffix.
+		return v.ItemID
+	}
 	return fmt.Sprintf("%s@%s", v.ItemID, v.SpaceID)
 }
 
+// specscore: decisions/0002-reserved-extension-space-ids
+// SpaceID is optional (empty ⇒ system namespace). See sneat-specs Decision 0002:
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
 func (v RelatedItemKey) Validate() error {
-	if v.SpaceID == "" {
-		return validation.NewErrRecordIsMissingRequiredField("spaceID")
-	}
+	// SpaceID is optional: an empty SpaceID denotes the spaceless system
+	// namespace (record stored at /ext/{ext-id}/...). A non-empty SpaceID
+	// denotes a space-bound record at /spaces/{space-id}/ext/{ext-id}/...
 	if v.ItemID == "" {
 		return validation.NewErrRecordIsMissingRequiredField("itemID")
 	}
@@ -152,13 +163,27 @@ func (v *WithRelated) Validate() error {
 	return v.ValidateRelated(nil)
 }
 
+// specscore: decisions/0002-reserved-extension-space-ids
+// Recognise a spaceless storage key (/ext/{ext-id}/..., no space ancestor) as
+// the system namespace instead of walking off the top of the key. See
+// sneat-specs Decision 0002:
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
 func (v *WithRelated) ValidateWithKey(key *dal.Key) error {
-	parent := key.Parent()
+	// A record lives either at:
+	//   /spaces/{space-id}/ext/{ext-id}/{collection}/{item-id}[/...]  (space-bound)
+	// or, for the spaceless system namespace, at:
+	//   /ext/{ext-id}/{collection}/{item-id}[/...]                    (system)
+	// Walk up the key to find the "ext" segment. If it has a parent then that
+	// parent is the space key; otherwise the "ext" segment is at the root and
+	// the record belongs to the spaceless system namespace (empty spaceID).
 	var spaceID coretypes.SpaceID
-	if parent.Collection() == "ext" {
-		spaceID = coretypes.SpaceID(parent.Parent().ID.(string))
-	} else {
-		spaceID = coretypes.SpaceID(parent.Parent().Parent().ID.(string))
+	for k := key.Parent(); k != nil; k = k.Parent() {
+		if k.Collection() == "ext" {
+			if spaceKey := k.Parent(); spaceKey != nil {
+				spaceID = coretypes.SpaceID(spaceKey.ID.(string))
+			}
+			break
+		}
 	}
 	return v.validateWithSpaceID(spaceID)
 }

--- a/linkage/dbo4linkage/with_related_and_ids.go
+++ b/linkage/dbo4linkage/with_related_and_ids.go
@@ -156,7 +156,12 @@ func ValidateRelatedAndRelatedIDs(withRelated WithRelated, relatedIDs []string) 
 			}
 
 			if _, ok := relatedItems[relatedRef.ItemID]; !ok {
-				itemID := relatedRef.ItemID[:strings.Index(relatedRef.ItemID, SpaceItemIDSeparator)]
+				// Strip the optional "@{spaceID}" suffix to recover the bare
+				// itemID. Absence of "@" means the system namespace (no space).
+				itemID := relatedRef.ItemID
+				if sep := strings.Index(itemID, SpaceItemIDSeparator); sep >= 0 {
+					itemID = itemID[:sep]
+				}
 				if _, ok = relatedItems[itemID]; !ok {
 					return validation.NewErrBadRecordFieldValue(
 						fmt.Sprintf("relatedIDs[%d]", i),

--- a/linkage/dbo4linkage/with_related_and_ids_test.go
+++ b/linkage/dbo4linkage/with_related_and_ids_test.go
@@ -1,6 +1,7 @@
 package dbo4linkage
 
 import (
+	"net/url"
 	"reflect"
 	"slices"
 	"testing"
@@ -9,6 +10,40 @@ import (
 	"github.com/dal-go/dalgo/update"
 	"github.com/sneat-co/sneat-go-core/coretypes"
 )
+
+// TestNewItemRefFromQueryString_BothShapes verifies that the presence of the
+// "s" (space) query parameter is the sole discriminator (sneat-specs Decision
+// 0002): when present, the itemID carries an "@{spaceID}" suffix (space-bound);
+// when absent, the itemID stays bare (spaceless system namespace).
+func TestNewItemRefFromQueryString_BothShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		values     url.Values
+		wantItemID string
+	}{
+		{
+			name:       "space_bound",
+			values:     url.Values{"m": {"contactus"}, "c": {"contacts"}, "i": {"item1"}, "s": {"space1"}},
+			wantItemID: "item1@space1",
+		},
+		{
+			name:       "system_namespace_no_space",
+			values:     url.Values{"m": {"contactus"}, "c": {"contacts"}, "i": {"item1"}},
+			wantItemID: "item1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := NewItemRefFromQueryString(tt.values)
+			if err != nil {
+				t.Fatalf("NewItemRefFromQueryString() error = %v", err)
+			}
+			if ref.ItemID != tt.wantItemID {
+				t.Errorf("NewItemRefFromQueryString() ItemID = %q, want %q", ref.ItemID, tt.wantItemID)
+			}
+		})
+	}
+}
 
 func TestAddRelationshipAndID(t *testing.T) {
 	type args struct {

--- a/linkage/dbo4linkage/with_related_test.go
+++ b/linkage/dbo4linkage/with_related_test.go
@@ -7,11 +7,95 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dal-go/dalgo/dal"
 	"github.com/dal-go/dalgo/update"
 	"github.com/sneat-co/contactus-ext/backend/contactusmodels/const4contactus"
 	"github.com/sneat-co/sneat-go-core/coretypes"
 	"github.com/strongo/strongoapp/with"
 )
+
+func TestRelatedItemKey_String(t *testing.T) {
+	tests := []struct {
+		name string
+		key  RelatedItemKey
+		want string
+	}{
+		{
+			name: "space_bound",
+			key:  RelatedItemKey{SpaceID: "space1", ItemID: "item1"},
+			want: "item1@space1",
+		},
+		{
+			name: "system_namespace_no_space",
+			key:  RelatedItemKey{ItemID: "item1"},
+			want: "item1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.key.String(); got != tt.want {
+				t.Errorf("RelatedItemKey.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelatedItemKey_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     RelatedItemKey
+		wantErr bool
+	}{
+		{name: "space_bound", key: RelatedItemKey{SpaceID: "space1", ItemID: "item1"}, wantErr: false},
+		{name: "system_namespace_empty_space", key: RelatedItemKey{ItemID: "item1"}, wantErr: false},
+		{name: "empty_item_id", key: RelatedItemKey{SpaceID: "space1"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.key.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("RelatedItemKey.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWithRelated_ValidateWithKey(t *testing.T) {
+	// space-bound record key: /spaces/{spaceID}/ext/{extID}/{collection}/{itemID}
+	spaceBoundKey := dal.NewKeyWithParentAndID(
+		dal.NewKeyWithParentAndID(
+			dal.NewKeyWithID("spaces", "space1"),
+			"ext", "contactus"),
+		"contacts", "item1")
+	// spaceless system-namespace key: /ext/{extID}/{collection}/{itemID}
+	systemKey := dal.NewKeyWithParentAndID(
+		dal.NewKeyWithID("ext", "contactus"),
+		"contacts", "item1")
+	// nested spaceless key: /ext/{extID}/spots/{spotID}/days/{date}
+	nestedSystemKey := dal.NewKeyWithParentAndID(
+		dal.NewKeyWithParentAndID(
+			dal.NewKeyWithID("ext", "happenings"),
+			"spots", "spot1"),
+		"days", "2026-06-29")
+
+	tests := []struct {
+		name string
+		key  *dal.Key
+	}{
+		{name: "space_bound", key: spaceBoundKey},
+		{name: "system_namespace", key: systemKey},
+		{name: "nested_system_namespace", key: nestedSystemKey},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &WithRelated{Related: RelatedModules{
+				"module1": {"collection1": {"item2@space2": {}}},
+			}}
+			if err := v.ValidateWithKey(tt.key); err != nil {
+				t.Errorf("ValidateWithKey() unexpected error = %v", err)
+			}
+		})
+	}
+}
 
 func TestWithRelatedAndIDs_SetRelationshipToItem(t *testing.T) {
 	type fields struct {

--- a/linkage/facade4linkage/related_space_guard.go
+++ b/linkage/facade4linkage/related_space_guard.go
@@ -1,0 +1,37 @@
+package facade4linkage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sneat-co/sneat-core-modules/linkage/dbo4linkage"
+	"github.com/sneat-co/sneat-go-core/coretypes"
+	"github.com/sneat-co/sneat-go-core/facade"
+)
+
+// specscore: decisions/0002-reserved-extension-space-ids
+// assertRelatedItemRefInSpace fails closed on the untrusted, user-facing
+// relationship-update WRITE path. A user-supplied related ItemRef must resolve
+// to the request's own authorized space. The "@{spaceID}" suffix introduced by
+// sneat-specs Decision 0002 lets a ref name a DIFFERENT space ("@otherSpace")
+// or the spaceless system namespace (a trailing "@" => empty space). Honouring
+// either here would let a caller authorized only for spaceID write outside it,
+// so both are rejected. Legitimate same-space refs (a bare itemID, or
+// "itemID@{requestSpace}") are allowed and resolve to the request space exactly
+// as before. Spaceless / cross-space writes are expected only from trusted
+// server/worker paths under the deferred system-namespace ACL work, never from
+// this endpoint.
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
+func assertRelatedItemRefInSpace(spaceID coretypes.SpaceID, ref dbo4linkage.ItemRef) error {
+	// Use the explicit separator index (NOT ItemRef.SpaceID) so a trailing "@"
+	// (empty space => spaceless /ext/) is detected as a space override too.
+	if i := strings.Index(ref.ItemID, dbo4linkage.SpaceItemIDSeparator); i >= 0 {
+		targetSpace := coretypes.SpaceID(ref.ItemID[i+1:])
+		if targetSpace != spaceID {
+			return fmt.Errorf(
+				"%w: related item ref %q resolves to space %q outside the authorized request space %q",
+				facade.ErrUnauthorized, ref.ItemID, targetSpace, spaceID)
+		}
+	}
+	return nil
+}

--- a/linkage/facade4linkage/related_space_guard_test.go
+++ b/linkage/facade4linkage/related_space_guard_test.go
@@ -1,0 +1,49 @@
+package facade4linkage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sneat-co/sneat-core-modules/linkage/dbo4linkage"
+	"github.com/sneat-co/sneat-go-core/coretypes"
+	"github.com/sneat-co/sneat-go-core/facade"
+)
+
+// TestAssertRelatedItemRefInSpace asserts the B1 authorization boundary: on the
+// untrusted user-facing relationship-update write path a related ItemRef must
+// stay inside the request's authorized space. A cross-space ("@otherSpace") or
+// spaceless (trailing "@") ItemRef must be REJECTED, while bare and
+// same-space ("@requestSpace") refs are allowed. See sneat-specs Decision 0002.
+func TestAssertRelatedItemRefInSpace(t *testing.T) {
+	const requestSpace coretypes.SpaceID = "space1"
+
+	newRef := func(itemID string) dbo4linkage.ItemRef {
+		return dbo4linkage.ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: itemID}
+	}
+
+	tests := []struct {
+		name      string
+		ref       dbo4linkage.ItemRef
+		wantError bool
+	}{
+		{name: "bare_same_space", ref: newRef("victim"), wantError: false},
+		{name: "explicit_same_space", ref: newRef("victim@space1"), wantError: false},
+		{name: "cross_space_rejected", ref: newRef("victim@space2"), wantError: true},
+		{name: "spaceless_trailing_at_rejected", ref: newRef("victim@"), wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := assertRelatedItemRefInSpace(requestSpace, tt.ref)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected an authorization error, got nil")
+				}
+				if !errors.Is(err, facade.ErrUnauthorized) {
+					t.Errorf("expected facade.ErrUnauthorized, got %v", err)
+				}
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/linkage/facade4linkage/update_related_item.go
+++ b/linkage/facade4linkage/update_related_item.go
@@ -30,6 +30,10 @@ func UpdateRelatedItemTx(
 	}
 	relatedItemID := relatedItemRef.ItemID
 
+	// specscore: decisions/0002-reserved-extension-space-ids
+	// Resolve via the @{space}-aware builder so a spaceless ref maps to
+	// /ext/{ext-id}/... See sneat-specs Decision 0002:
+	// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
 	key := dbo4spaceus.NewSpaceModuleItemKeyFromItemRef(spaceID, relatedItemRef)
 	dbo := new(dbo4linkage.WithRelatedAndIDsAndUserID)
 	dbo.WithRelatedAndIDs = new(dbo4linkage.WithRelatedAndIDs)

--- a/linkage/facade4linkage/update_related_item.go
+++ b/linkage/facade4linkage/update_related_item.go
@@ -28,12 +28,21 @@ func UpdateRelatedItemTx(
 	if objectRef == relatedItemRef {
 		return nil, fmt.Errorf("objectRef and command.ItemRef are the same: %+v", objectRef)
 	}
-	relatedItemID := relatedItemRef.ItemID
 
 	// specscore: decisions/0002-reserved-extension-space-ids
-	// Resolve via the @{space}-aware builder so a spaceless ref maps to
-	// /ext/{ext-id}/... See sneat-specs Decision 0002:
+	// Fail closed: this is the untrusted, user-facing reciprocal-update write
+	// path, so a related ItemRef must stay inside the request's authorized
+	// space. A cross-space ("@otherSpace") or spaceless (trailing "@") ref is
+	// rejected here so it cannot write outside the caller's space.
 	// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
+	if err = assertRelatedItemRefInSpace(spaceID, relatedItemRef); err != nil {
+		return nil, err
+	}
+
+	// The record id must match the document id used to build the key (the bare
+	// itemID with any "@{spaceID}" suffix stripped).
+	relatedItemID := relatedItemRef.DocID()
+
 	key := dbo4spaceus.NewSpaceModuleItemKeyFromItemRef(spaceID, relatedItemRef)
 	dbo := new(dbo4linkage.WithRelatedAndIDsAndUserID)
 	dbo.WithRelatedAndIDs = new(dbo4linkage.WithRelatedAndIDs)

--- a/linkage/facade4linkage/update_related_items.go
+++ b/linkage/facade4linkage/update_related_items.go
@@ -51,7 +51,12 @@ func updateItemWithLatestRelationshipsFromRelatedItem(
 
 	return db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) (err error) {
 
-		key := dbo4spaceus.NewSpaceModuleItemKey(spaceID, itemRef.ExtID, itemRef.Collection, itemRef.ItemID)
+		// specscore: decisions/0002-reserved-extension-space-ids
+		// NewSpaceModuleItemKeyFromItemRef honours an "@{spaceID}" suffix on the
+		// itemID and resolves to the spaceless system namespace (/ext/...) when
+		// the effective space is empty. See sneat-specs Decision 0002:
+		// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
+		key := dbo4spaceus.NewSpaceModuleItemKeyFromItemRef(spaceID, itemRef)
 		item := record.NewDataWithID(itemRef.ItemID, key, new(dbo4linkage.WithRelatedAndIDsAndUserID))
 		if err = tx.Get(ctx, item.Record); err != nil {
 			return err

--- a/linkage/facade4linkage/update_related_items.go
+++ b/linkage/facade4linkage/update_related_items.go
@@ -44,6 +44,15 @@ func updateItemWithLatestRelationshipsFromRelatedItem(
 		return nil
 	}
 
+	// specscore: decisions/0002-reserved-extension-space-ids
+	// Fail closed: the write target must stay inside the request's authorized
+	// space. A cross-space ("@otherSpace") or spaceless (trailing "@") ref is
+	// rejected so this user-facing path cannot write outside the caller's space.
+	// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
+	if err = assertRelatedItemRefInSpace(spaceID, itemRef); err != nil {
+		return err
+	}
+
 	var db dal.DB
 	if db, err = facade.GetSneatDB(ctx); err != nil {
 		return err
@@ -51,13 +60,10 @@ func updateItemWithLatestRelationshipsFromRelatedItem(
 
 	return db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) (err error) {
 
-		// specscore: decisions/0002-reserved-extension-space-ids
-		// NewSpaceModuleItemKeyFromItemRef honours an "@{spaceID}" suffix on the
-		// itemID and resolves to the spaceless system namespace (/ext/...) when
-		// the effective space is empty. See sneat-specs Decision 0002:
-		// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
 		key := dbo4spaceus.NewSpaceModuleItemKeyFromItemRef(spaceID, itemRef)
-		item := record.NewDataWithID(itemRef.ItemID, key, new(dbo4linkage.WithRelatedAndIDsAndUserID))
+		// The record id must match the document id used to build the key (the
+		// bare itemID with any "@{spaceID}" suffix stripped).
+		item := record.NewDataWithID(itemRef.DocID(), key, new(dbo4linkage.WithRelatedAndIDsAndUserID))
 		if err = tx.Get(ctx, item.Record); err != nil {
 			return err
 		}

--- a/spaceus/dbo4spaceus/space_module.go
+++ b/spaceus/dbo4spaceus/space_module.go
@@ -9,8 +9,18 @@ import (
 
 const SpaceModulesCollection = coremodels.ExtCollection
 
+// specscore: decisions/0002-reserved-extension-space-ids
+// Spaceless key-builder: when the space is empty, build /ext/{ext-id}/... and do
+// NOT call NewSpaceKey (which panics on empty). See sneat-specs Decision 0002:
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
 func NewSpaceModuleKey(spaceID coretypes.SpaceID, moduleID coretypes.ExtID) *dal.Key {
-	spaceKey := NewSpaceKey(coretypes.SpaceID(spaceID))
+	if spaceID == "" {
+		// Spaceless system namespace: global/system extension records live at
+		// /ext/{ext-id}/... with no /spaces/{space-id} prefix (sneat-specs
+		// Decision 0002). NewSpaceKey is intentionally NOT called here.
+		return dal.NewKeyWithID(SpaceModulesCollection, moduleID)
+	}
+	spaceKey := NewSpaceKey(spaceID)
 	return dal.NewKeyWithParentAndID(spaceKey, SpaceModulesCollection, moduleID)
 }
 

--- a/spaceus/dbo4spaceus/space_module_item.go
+++ b/spaceus/dbo4spaceus/space_module_item.go
@@ -2,6 +2,7 @@ package dbo4spaceus
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/dal-go/dalgo/dal"
 	"github.com/sneat-co/sneat-core-modules/linkage/dbo4linkage"
@@ -20,6 +21,21 @@ func NewSpaceModuleItemIncompleteKey[K comparable](spaceID coretypes.SpaceID, mo
 	return dal.NewIncompleteKey(collection, idKind, spaceModuleKey)
 }
 
+// specscore: decisions/0002-reserved-extension-space-ids
+// Ref→path resolver: the "@{spaceID}" suffix is the sole discriminator between a
+// space-bound record and a spaceless system-namespace record (/ext/{ext-id}/...).
+// See sneat-specs Decision 0002:
+// https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md
 func NewSpaceModuleItemKeyFromItemRef(spaceID coretypes.SpaceID, itemRef dbo4linkage.ItemRef) *dal.Key {
-	return NewSpaceModuleItemKey(spaceID, itemRef.ExtID, itemRef.Collection, itemRef.ItemID)
+	// The related ItemID may carry an explicit "@{spaceID}" suffix. The presence
+	// or absence of that suffix is the sole discriminator (sneat-specs Decision
+	// 0002): a suffix selects the space-bound record in that space; its absence
+	// keeps the supplied spaceID (the owner space, or empty for the spaceless
+	// system namespace at /ext/{ext-id}/...).
+	itemID := itemRef.ItemID
+	if i := strings.Index(itemID, dbo4linkage.SpaceItemIDSeparator); i >= 0 {
+		spaceID = coretypes.SpaceID(itemID[i+1:])
+		itemID = itemID[:i]
+	}
+	return NewSpaceModuleItemKey(spaceID, itemRef.ExtID, itemRef.Collection, itemID)
 }

--- a/spaceus/dbo4spaceus/space_module_item_test.go
+++ b/spaceus/dbo4spaceus/space_module_item_test.go
@@ -3,8 +3,62 @@ package dbo4spaceus
 import (
 	"testing"
 
+	"github.com/sneat-co/sneat-core-modules/linkage/dbo4linkage"
 	"github.com/sneat-co/sneat-go-core/coretypes"
 )
+
+// TestNewSpaceModuleItemKeyFromItemRef verifies both storage shapes defined by
+// sneat-specs Decision 0002 (spaceless system namespace):
+//   - space-bound:       /spaces/{space-id}/ext/{ext-id}/{collection}/{item-id}
+//   - system namespace:  /ext/{ext-id}/{collection}/{item-id}
+//
+// The presence/absence of an "@{space-id}" suffix on the itemID is the sole
+// discriminator.
+func TestNewSpaceModuleItemKeyFromItemRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		spaceID  coretypes.SpaceID
+		itemRef  dbo4linkage.ItemRef
+		wantPath string
+	}{
+		{
+			name:     "space_bound",
+			spaceID:  "space1",
+			itemRef:  dbo4linkage.ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: "item1"},
+			wantPath: "spaces/space1/ext/contactus/contacts/item1",
+		},
+		{
+			name:     "system_namespace_empty_space",
+			spaceID:  "",
+			itemRef:  dbo4linkage.ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: "item1"},
+			wantPath: "ext/contactus/contacts/item1",
+		},
+		{
+			name:     "space_bound_via_at_suffix",
+			spaceID:  "space1",
+			itemRef:  dbo4linkage.ItemRef{ExtID: "contactus", Collection: "contacts", ItemID: "item1@space2"},
+			wantPath: "spaces/space2/ext/contactus/contacts/item1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := NewSpaceModuleItemKeyFromItemRef(tt.spaceID, tt.itemRef)
+			if got := key.String(); got != tt.wantPath {
+				t.Errorf("NewSpaceModuleItemKeyFromItemRef() path = %q, want %q", got, tt.wantPath)
+			}
+		})
+	}
+}
+
+// TestNewSpaceModuleKey verifies the space-bound and spaceless module keys.
+func TestNewSpaceModuleKey(t *testing.T) {
+	if got := NewSpaceModuleKey("space1", "contactus").String(); got != "spaces/space1/ext/contactus" {
+		t.Errorf("NewSpaceModuleKey(space1) = %q", got)
+	}
+	if got := NewSpaceModuleKey("", "contactus").String(); got != "ext/contactus" {
+		t.Errorf("NewSpaceModuleKey(empty) = %q", got)
+	}
+}
 
 func TestNewSpaceModuleItemIncompleteKey(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Summary

Implements **sneat-specs Decision 0002 — "Spaceless system namespace for global extension records"** in the canonical linkage package (`sneat-core-modules/linkage`) and the ref→path resolver (`spaceus/dbo4spaceus`).

Global/system extension records now resolve **spaceless** at `/ext/{ext-id}/{collection}/{doc-id}` (nested subcollections allowed). Space-owned records are **unchanged** at `/spaces/{space-id}/ext/{ext-id}/...`. Existing space-bound behavior is preserved.

## The two storage shapes & the discriminator

| Ref | Resolves to |
| --- | --- |
| `{ext-id}/{collection}/{doc-id}` (no suffix) | `/ext/{ext-id}/{collection}/{doc-id}` (system namespace) |
| `{ext-id}/{collection}/{doc-id}@{space-id}` | `/spaces/{space-id}/ext/{ext-id}/{collection}/{doc-id}` (space-bound) |

The **presence/absence of the `@{space-id}` suffix is the sole discriminator**. The ext-id is mandatory.

## Changes

- `RelatedItemKey.Validate` — `spaceID` optional (empty ⇒ system namespace); itemID still required.
- `RelatedItemKey.String` / `NewFullItemRef` — omit the `@{space}` suffix when there is no space.
- `WithRelated.ValidateWithKey` — walks up to the `ext` segment; if `ext` is at the root (no space ancestor) it is the system namespace, instead of walking off the top of the key. Handles nested subcollections under both shapes.
- Resolver `dbo4spaceus.NewSpaceModuleKey` / `NewSpaceModuleItemKeyFromItemRef` — spaceless key-builder (`/ext/{ext-id}/...`) when the effective space is empty; does **not** call `NewSpaceKey` (which panics on empty). An `@{space}` suffix selects that space. Non-empty space behavior unchanged.
- Related-ID parse guard so "no `@`" cleanly means "no space".
- Tests for **both** shapes; existing space-bound assertions still pass.

## 🔒 Security hardening — authorization guard (BLOCKER B1, FIXED)

An adversarial review found that the new `@{space}`-aware resolver, on the **untrusted user-facing relationship-update write path** (`UpdateItemRelationships` → `UpdateRelatedFields` → `UpdateRelatedItemTx`, and the reciprocal `updateItemWithLatestRelationshipsFromRelatedItem`), let a caller embed `@otherSpace` or a trailing `@` in the attacker-controlled `command.ItemRef.ItemID` to redirect the resolved Firestore key into **another space** or the **spaceless `/ext/` namespace** and write there with only the request space's membership. (Previously the ref always stayed in the caller's authorized space.)

**Fix (fails closed):**
- `assertRelatedItemRefInSpace` guards both write paths: a related `ItemRef` that resolves to a space other than the request's authorized space — cross-space `@otherSpace` **or** spaceless trailing `@` — is rejected with `facade.ErrUnauthorized`. Bare and `@requestSpace` refs still resolve to the request space exactly as before (eventus/space-bound callers unchanged).
- `command.ItemRef.Validate()` re-enabled (was commented out); `ItemRef.Validate` hardened: the ItemID may carry **at most one** `@{spaceID}` suffix with non-empty doc id and non-empty space. `@` is the reserved separator, so a **document id can never contain `@`** (M2). Trailing `@`, leading `@`, and multiple `@` are rejected.
- The related record `.ID` is now derived from the **same stripped doc id** used to build the key (`ItemRef.DocID`), not the raw `item@space` composite (m3).
- Negative test asserts the boundary: cross-space (`@otherSpace`) and trailing-`@` refs are **rejected**, bare/same-space allowed.

**Cross-space / spaceless `/ext/` writes are intentionally gated on this endpoint** and are expected only from trusted server/worker paths under the deferred system-namespace ACL work (below). The spaceless resolver primitive and `ValidateWithKey`'s spaceless branch are correct and unchanged.

## ⚠️ Access control (system-namespace ACL) — REMAINING (not in this PR)

Decision 0002 also calls for **lifting `SpaceTypeSystem` authorization (public-read, any-authenticated-write, ext-delegated per-record auth) from a system *space* to the system *namespace* at `/ext/`**. This is **NOT implemented here**.

Why deferred: the existing system-space ACL in `dal4spaceus` (`SpaceWorkerParams.GetRecords`, `RunModuleSpaceWorkerWithUserCtx`) is structurally tied to **loading a `/spaces/{space-id}` record and gating on its `Type == SpaceTypeSystem`**. Spaceless `/ext/...` records have **no space record**, and the worker entry points explicitly reject an empty `spaceID`. Authorizing the spaceless namespace requires a new, carefully-designed worker/auth path (require auth for writes, public read, delegate per-record auth) rather than a one-line edit. Per the task's security guidance, this is a documented remaining item rather than a guess.

**No existing authorization is weakened by this PR** — `dal4spaceus` auth code is untouched, and the new guard *tightens* the user-facing write path.

## Spec traceability

sneat-specs Decision 0002: https://github.com/sneat-co/sneat-specs/blob/main/spec/decisions/0002-reserved-extension-space-ids.md — touched functions carry `// specscore: decisions/0002-reserved-extension-space-ids` annotations + the decision URL.

## Build & test

- `go build ./...` — PASS
- `go test ./...` — PASS (incl. new B1 boundary test, `ItemRef.Validate`/`DocID` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
