### PR TITLE
fix: GenerateNewSpaceModuleItemKey never returned a free key

### DIFF
--- a/spaceus/dal4spaceus/space_module_item_key_generator.go
+++ b/spaceus/dal4spaceus/space_module_item_key_generator.go
@@ -22,12 +22,19 @@ func GenerateNewSpaceModuleItemKey(ctx context.Context, tx dal.ReadwriteTransact
 	for i := 0; i < maxAttempts; i++ {
 		id = random.ID(length)
 		key = dbo4spaceus.NewSpaceModuleItemKey(spaceID, moduleID, collection, id)
-		if _, err = tx.Exists(ctx, key); err != nil { // TODO: use tx.Exists()
-			if dal.IsNotFound(err) {
-				return id, key, nil
-			}
+		// tx.Exists reports a missing document as (false, nil) — it does NOT
+		// return a not-found error (dalgo2firestore clears it). So branch on the
+		// returned bool: a non-existent key is the free id we want. The earlier
+		// `if err != nil { if dal.IsNotFound(err) … }` form never fired (err was
+		// always nil) and so always exhausted maxAttempts — breaking every
+		// space-module item create (e.g. eventus event → calendarius happening).
+		var exists bool
+		if exists, err = tx.Exists(ctx, key); err != nil {
 			return "", nil, err
 		}
+		if !exists {
+			return id, key, nil
+		}
 	}
-	return "", nil, errors.New("too many attempts  to generate a random happening ContactID")
+	return "", nil, errors.New("too many attempts to generate a random happening ContactID")
 }

--- a/spaceus/dal4spaceus/space_module_item_key_generator_test.go
+++ b/spaceus/dal4spaceus/space_module_item_key_generator_test.go
@@ -2,6 +2,7 @@ package dal4spaceus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -9,6 +10,75 @@ import (
 	"github.com/sneat-co/sneat-go-core/coretypes"
 	"github.com/stretchr/testify/assert"
 )
+
+// fakeExistsTx is a minimal ReadwriteTransaction that only implements Exists
+// (the single method GenerateNewSpaceModuleItemKey calls). Every other method
+// would panic via the embedded nil interface, which is fine for these tests.
+type fakeExistsTx struct {
+	dal.ReadwriteTransaction
+	// existsResults is consumed one entry per Exists() call, modelling a
+	// sequence of collisions (true) followed by a free key (false).
+	existsResults []bool
+	calls         int
+	err           error
+}
+
+func (f *fakeExistsTx) Exists(context.Context, *dal.Key) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	exists := false
+	if f.calls < len(f.existsResults) {
+		exists = f.existsResults[f.calls]
+	}
+	f.calls++
+	return exists, nil
+}
+
+// TestGenerateNewSpaceModuleItemKey_HappyPath is the regression for the bug
+// where Exists reports a missing doc as (false, nil) — not a not-found error —
+// so the old `if err != nil { if dal.IsNotFound(err) … }` form never returned an
+// id and always exhausted maxAttempts. A free key must yield a valid id.
+func TestGenerateNewSpaceModuleItemKey_HappyPath(t *testing.T) {
+	tx := &fakeExistsTx{} // no collisions: every Exists → (false, nil)
+	id, key, err := GenerateNewSpaceModuleItemKey(
+		context.Background(), tx, "space1", "eventus", "events", 5, 10)
+	assert.NoError(t, err)
+	assert.Len(t, id, 5)
+	assert.NotNil(t, key)
+	assert.Equal(t, 1, tx.calls, "should return on the first free key, not loop")
+}
+
+// TestGenerateNewSpaceModuleItemKey_RetriesPastCollisions verifies a collision
+// on the first attempt is skipped and the next free key is returned.
+func TestGenerateNewSpaceModuleItemKey_RetriesPastCollisions(t *testing.T) {
+	tx := &fakeExistsTx{existsResults: []bool{true, false}}
+	id, _, err := GenerateNewSpaceModuleItemKey(
+		context.Background(), tx, "space1", "eventus", "events", 5, 10)
+	assert.NoError(t, err)
+	assert.Len(t, id, 5)
+	assert.Equal(t, 2, tx.calls, "should retry once past the collision")
+}
+
+// TestGenerateNewSpaceModuleItemKey_ExhaustsAttempts verifies that when every
+// candidate key collides, the generator gives up after maxAttempts.
+func TestGenerateNewSpaceModuleItemKey_ExhaustsAttempts(t *testing.T) {
+	tx := &fakeExistsTx{existsResults: []bool{true, true, true}}
+	_, _, err := GenerateNewSpaceModuleItemKey(
+		context.Background(), tx, "space1", "eventus", "events", 5, 3)
+	assert.Error(t, err)
+	assert.Equal(t, 3, tx.calls)
+}
+
+// TestGenerateNewSpaceModuleItemKey_ExistsError verifies a real Exists error is
+// propagated rather than swallowed or retried.
+func TestGenerateNewSpaceModuleItemKey_ExistsError(t *testing.T) {
+	wantErr := errors.New("boom")
+	tx := &fakeExistsTx{err: wantErr}
+	_, _, err := GenerateNewSpaceModuleItemKey(
+		context.Background(), tx, "space1", "eventus", "events", 5, 10)
+	assert.ErrorIs(t, err, wantErr)
+}
 
 func TestGenerateNewSpaceModuleItemKey(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Problem

`GenerateNewSpaceModuleItemKey` detected a free key by relying on `tx.Exists` returning a **not-found error**:

```go
if _, err = tx.Exists(ctx, key); err != nil {
    if dal.IsNotFound(err) {
        return id, key, nil // free id
    }
    return "", nil, err
}
```

But `dalgo2firestore` reports a missing document as `(false, nil)` — it clears the not-found error. So `err` was always `nil`, the "free id" branch never fired, and the loop always exhausted `maxAttempts`:

> too many attempts to generate a random happening ContactID

This breaks **every** space-module item create — e.g. an eventus event → calendarius happening (`CreateSpaceItem`) — against Firestore.

## Fix

Branch on the returned `exists` bool (the actual API contract) instead of the error:

```go
exists, err := tx.Exists(ctx, key)
if err != nil { return "", nil, err }
if !exists { return id, key, nil }
```

## Tests

The previous test only covered the nil-`tx` panic, which is why this slipped through. Adds happy-path, retry-past-collision, exhaustion, and error-propagation tests (the happy-path test fails against the old code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)