### PR TITLE
fix(dal4spaceus): GenerateNewSpaceModuleItemKey honours tx.Exists bool

### DIFF
--- a/spaceus/dal4spaceus/space_module_item_key_generator.go
+++ b/spaceus/dal4spaceus/space_module_item_key_generator.go
@@ -22,12 +22,15 @@ func GenerateNewSpaceModuleItemKey(ctx context.Context, tx dal.ReadwriteTransact
 	for i := 0; i < maxAttempts; i++ {
 		id = random.ID(length)
 		key = dbo4spaceus.NewSpaceModuleItemKey(spaceID, moduleID, collection, id)
-		if _, err = tx.Exists(ctx, key); err != nil { // TODO: use tx.Exists()
-			if dal.IsNotFound(err) {
-				return id, key, nil
-			}
+		// tx.Exists returns (exists, nil) for a free key — it does NOT return a
+		// not-found error. The old code only reacted to err != nil, so a free key
+		// (false, nil) was never returned and the loop always exhausted maxAttempts.
+		var exists bool
+		if exists, err = tx.Exists(ctx, key); err != nil {
 			return "", nil, err
+		} else if !exists {
+			return id, key, nil
 		}
 	}
-	return "", nil, errors.New("too many attempts  to generate a random happening ContactID")
+	return "", nil, errors.New("too many attempts to generate a random space module item key")
 }


### PR DESCRIPTION
## Problem
`GenerateNewSpaceModuleItemKey` mishandled the `tx.Exists` contract: a free key returns `(false, nil)` — **no** not-found error. The old code only reacted to `err != nil` (then `dal.IsNotFound(err)`), so a free key was never returned and the loop always exhausted `maxAttempts` → `"too many attempts to generate a random ... ID"`.

This blocked **all** happening / space-module-item creation (surfaced by the ReQuoter onboard e2e and previously by the eventus harness).

## Fix
Use the bool return value: `err → return err`; `!exists → key is free, return it`; `exists → retry`.

Already released for the v0.39.x line as **v0.39.2** (backport); this brings the fix to mainline for future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qkn8HwBQo56u278ZPTGxmv