### PR TITLE
security(SEC-3): restore AdminOnly rejection for non-admin callers

### DIFF
--- a/auth/api4auth/api_auth.go
+++ b/auth/api4auth/api_auth.go
@@ -62,8 +62,8 @@ func AdminOnly(handler AuthHandler) strongoapp.HttpHandlerWithContext {
 		if authInfo, _, err := token4auth.Authenticate(w, r, true); err == nil {
 			if !authInfo.IsAdmin {
 				logus.Debugf(ctx, "Not admin!")
-				//hashedWriter.WriteHeader(http.StatusForbidden)
-				//return
+				w.WriteHeader(http.StatusForbidden)
+				return
 			}
 			handler(ctx, w, r, authInfo)
 		} else {


### PR DESCRIPTION
## Bug
`AdminOnly()` in `auth/api4auth/api_auth.go` (~line 60-73) logged `"Not admin!"` for non-admin authenticated callers but then fell through and invoked the protected handler anyway — the `403 Forbidden` write and `return` were commented out:

```go
if !authInfo.IsAdmin {
    logus.Debugf(ctx, "Not admin!")
    //hashedWriter.WriteHeader(http.StatusForbidden)
    //return
}
handler(ctx, w, r, authInfo)
```

This effectively disabled the admin gate: any authenticated (non-admin) user could call any endpoint wrapped with `AdminOnly` and reach the handler.

## Fix
Restored real enforcement — on non-admin, write `http.StatusForbidden` and `return` without calling `handler`. Kept the existing debug log line.

## Impact
Any endpoint across consumer repos (e.g. `debtus/backend`) wrapped with `api4auth.AdminOnly` was reachable by any authenticated non-admin user. Severity: high (privilege escalation / admin-only data & actions exposed).

## Verified
- No other callers in this repo depend on the broken fall-through (only definition site here; consumers are in downstream modules like `debtus/backend`).
- `go build ./...` passes.
- `go test ./auth/...` passes.

## Residual / follow-up
This repo is consumed by `sneat-go` which pins `sneat-core-modules v0.39.2`. A version bump + `sneat-go` go.mod update + redeploy is required to actually ship this fix to production — not done as part of this PR per policy (fix + PR only, no release/deploy).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FV3pbooAc9UPpNdiaJuKve